### PR TITLE
Fix generating haddock documentation

### DIFF
--- a/src/DBus.hs
+++ b/src/DBus.hs
@@ -104,15 +104,6 @@ module DBus
     , def
     ) where
 
--- $types
---
--- DBus has it's own type system, described here
--- <https://dbus.freedesktop.org/doc/dbus-specification.html#type-system>
---
--- Types are divided into basic types, represented in this library by
--- 'DBusSimpleType', and composite types, represented by 'DBusType'. Only simple
--- types can be the keys in a dictionary
-
 import DBus.Introspect
 import DBus.MainLoop
 import DBus.Message
@@ -132,3 +123,12 @@ ignore _ _ _ = return ()
 -- | Connect to a message bus as a client
 connectClient :: ConnectionType -> IO DBusConnection
 connectClient bus = connectBus bus ignore ignore
+
+-- $types
+--
+-- DBus has it's own type system, described here
+-- <https://dbus.freedesktop.org/doc/dbus-specification.html#type-system>
+--
+-- Types are divided into basic types, represented in this library by
+-- 'DBusSimpleType', and composite types, represented by 'DBusType'. Only simple
+-- types can be the keys in a dictionary

--- a/src/DBus/MainLoop.hs
+++ b/src/DBus/MainLoop.hs
@@ -222,12 +222,12 @@ data ConnectionType = System -- ^ The well-known system bus. First
                               -- DBUS_SESSION_BUS_ADDRESS
                     | Address String -- ^ The bus at the give addresss
 
-type MethodCallHandler = ( DBusConnection -- ^ Connection that the call was
+type MethodCallHandler = DBusConnection -- ^ Connection that the call was
                                           -- received from. Should be used to
                                           -- return the result or error
-                           -> MessageHeader
-                           -> [SomeDBusValue]
-                           -> IO ())
+                       -> MessageHeader
+                       -> [SomeDBusValue]
+                       -> IO ()
 
 type SignalHandler = ( DBusConnection
                        -> MessageHeader


### PR DESCRIPTION
Haddock was unable to parse seom code, so `cabal haddock` failed. This PR fixes that.