### PR TITLE
Fix connection/memory leak

### DIFF
--- a/src/DBus/MainLoop.hs
+++ b/src/DBus/MainLoop.hs
@@ -317,7 +317,7 @@ connectBusWithAuth transport auth handleCalls handleSignals = do
                                     propertySlots
                      ))
             (\e -> print (e :: Ex.SomeException) >> kill >> Ex.throwIO e)
-        addFinalizer aliveRef $ killThread handlerThread
+        addTVarFinalizer aliveRef $ killThread handlerThread
         let conn = DBusConnection { dBusCreateSerial = getSerial
                                   , dBusAnswerSlots = answerSlots
                                   , dbusSignalSlots = signalSlots
@@ -330,6 +330,10 @@ connectBusWithAuth transport auth handleCalls handleSignals = do
         connName <- hello conn
         debugM "DBus" $ "Done"
         return conn{dBusConnectionName = connName}
+
+  where
+    addTVarFinalizer :: TVar a -> IO () -> IO ()
+    addTVarFinalizer tvar fin = void $ mkWeakTVar tvar fin
 
 -- | Create a simple server that exports @Objects@ and ignores all incoming signals.
 --

--- a/src/DBus/MainLoop.hs
+++ b/src/DBus/MainLoop.hs
@@ -323,10 +323,8 @@ connectBusWithAuth transport auth handleCalls handleSignals = do
     -- Note that we update gcRef *outside* of the mfix block.
     conn <- mfix $ \conn' -> do
         debugM "DBus" $ "Forking"
-        handlerThread <- forkIO $ do
-
-          Ex.catch (do
-            CB.sourceHandle h
+        handlerThread <- forkIO $
+            (CB.sourceHandle h
                 C.$= parseMessages
                 C.$$ (C.awaitForever $ liftIO .
                       handleMessage (handleCalls conn')
@@ -334,8 +332,8 @@ connectBusWithAuth transport auth handleCalls handleSignals = do
                                     answerSlots
                                     signalSlots
                                     propertySlots
-                     ))
-            (\e -> print (e :: Ex.SomeException) >> kill >> Ex.throwIO e)
+                     )
+            ) `Ex.finally` kill
         addTVarFinalizer gcRef $ killThread handlerThread
         let conn = DBusConnection { dBusCreateSerial = getSerial
                                   , dBusAnswerSlots = answerSlots

--- a/src/DBus/Message.hs
+++ b/src/DBus/Message.hs
@@ -311,7 +311,7 @@ callMethod' dest path interface member args flags conn = do
     serial <- atomically $ dBusCreateSerial conn
     ref <- newEmptyTMVarIO
     rSlot <- newTVarIO ()
-    mkWeak rSlot (connectionAliveRef conn) Nothing
+    mkWeak rSlot (gcRef conn) Nothing
     _ <- mkWeakTVar rSlot (finalizeSlot serial)
     slot <- atomically $ do
         modifyTVar (dBusAnswerSlots conn) (Map.insert serial $ putTMVar ref)

--- a/src/DBus/Types.hs
+++ b/src/DBus/Types.hs
@@ -713,6 +713,9 @@ data DBusConnection =
         , dBusWriteLock :: TMVar (BS.Builder -> IO ())
         , dBusConnectionName :: Text
         , connectionAliveRef :: TVar Bool
+        , gcRef :: !(TVar ())
+          -- ^ A dummy TVar to which we attach a finalizer.
+          -- When this TVar is garbage-collected, the connection is closed.
         }
 
 data MethodDescription args rets where


### PR DESCRIPTION
Hi,

First of all, thanks for the library — we at @nstack use it with great success.

Unfortunately, we discovered that as it is right now, the library does not close the connections and leaks memory allocated to the connection thread.

There are two causes of this:

1. In order for the finalizer to run, it has to be attached to a TVar with a TVar-specific function.
2. The connection thread itself retains the connection object, and so it is never GC'd and the finalizer never runs.

You can reproduce the leak by observing the memory consumption of this simple program depending on the value of the argument:

``` haskell
import System.Environment
import qualified DBus as DBus
import Control.Monad
import System.Mem (performGC)

callDBusCommand :: IO ()
callDBusCommand = do
  _ <- DBus.connectClient DBus.System
  performGC

main = do
  n <- read . head <$> getArgs
  replicateM_ n callDBusCommand
```

This PR fixes the memory leak. It also removes the unnnecessary weak pointer on the alive ref and the unnecessary exception handler in the connection thread.