### PR TITLE
fix: big-endian messages identified with 'B' not 'b'

### DIFF
--- a/src/DBus/Message.hs
+++ b/src/DBus/Message.hs
@@ -150,10 +150,10 @@ makeRepresentable ''HeaderField
 instance Representable Endian where
     type RepType Endian = 'DBusSimpleType 'TypeByte
     toRep Little = DBVByte $ fromIntegral $ ord 'l'
-    toRep Big    = DBVByte $ fromIntegral $ ord 'b'
+    toRep Big    = DBVByte $ fromIntegral $ ord 'B'
     fromRep (DBVByte x) = case chr (fromIntegral x) of
         'l' -> Just Little
-        'b' -> Just Big
+        'B' -> Just Big
         _ -> Nothing
 
 data MessageHeader =


### PR DESCRIPTION
Big-endian messages are identified with captal `B` rather than lowercase `b`.

from https://dbus.freedesktop.org/doc/dbus-specification.html:

> Endianness flag; ASCII 'l' for little-endian or ASCII 'B' for big-endian. Both header and body are in this endianness.

I double checked this with the code for [sd-bus](https://github.com/systemd/systemd/blob/dd8352659c9428b196706d04399eec106a8917ed/src/libsystemd/sd-bus/bus-protocol.h#L62) and [another haskell dbus client](https://github.com/rblaze/haskell-dbus/blob/master/lib/DBus/Internal/Wire.hs#L62)