### PR TITLE
Fix for recent compilers and bump stack version

### DIFF
--- a/src/DBus/Types.hs
+++ b/src/DBus/Types.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
 
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.28
+resolver: lts-18.6
 
 packages:
 - '.'


### PR DESCRIPTION
Motivation for this change:

The project no longer build on recent versions of GHC. The first patch adds the extension _StandaloneKindSignatures_; which fixes the build on GHC 8.10.4 (but I suspect is required since its introduction on GHC 8.10.1).

I'm updating the stack file to a more recent release, but I'm happy to drop that commit if anyone oposes.